### PR TITLE
41_Controllerのテストと入力チェックのテスト

### DIFF
--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -76,4 +76,5 @@ public class Student {
     this.gender = gender;
     this.remark = remark;
   }
+
 }

--- a/src/main/java/raisetech/student/management/exception/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/student/management/exception/GlobalExceptionHandler.java
@@ -104,7 +104,13 @@ public class GlobalExceptionHandler {
     errors.put("path", req.getRequestURI());
     errors.put("message", "該当するデータが見つかりません。");
     return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
-   }
+  }
+
+  // 受講生情報が確認できない
+  @ExceptionHandler(NoDataException.class)
+  public ResponseEntity<String> handleNoDataException(NoDataException ex) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+  }
 
   // その他の例外
   @ExceptionHandler(Exception.class)

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -55,6 +55,10 @@ public class StudentService {
   public StudentDetail searchStudent(Integer studentId) {
     // 受け取ったstudentIDを元に受講生情報を検索
     Student student = repository.searchStudent(studentId);
+    // nullチェック
+    if (student == null) {
+      throw new NoDataException("該当する受講生が見つかりません。ID：" + studentId);
+    }
     // 受講生情報のstudentIDに基づいてコース情報を検索
     List<StudentsCourse> studentsCourses = repository.searchStudentsCourses(student.getStudentId());
     // ↑の受講生情報・コース情報を持つnew StudentDetailを生成してreturn

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -2,6 +2,7 @@ package raisetech.student.management.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,7 +57,7 @@ public class StudentService {
     // 受け取ったstudentIDを元に受講生情報を検索
     Student student = repository.searchStudent(studentId);
     // nullチェック
-    if (student == null) {
+    if (Objects.isNull(student)) {
       throw new NoDataException("該当する受講生が見つかりません。ID：" + studentId);
     }
     // 受講生情報のstudentIDに基づいてコース情報を検索

--- a/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/StudentControllerTest.java
@@ -1,0 +1,157 @@
+package raisetech.student.management.controller;
+
+import static jakarta.validation.Validation.buildDefaultValidatorFactory;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import raisetech.student.management.data.Student;
+import raisetech.student.management.data.StudentsCourse;
+import raisetech.student.management.domain.StudentDetail;
+import raisetech.student.management.service.StudentService;
+
+@WebMvcTest(StudentController.class)
+@Import(StudentControllerTest.MockConfig.class) // モックBeanを定義したクラスをインポート
+class StudentControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private StudentService service; // モックBeanを注入
+
+  private Student baseStudent;
+  private List<StudentsCourse> baseCourses;
+  private StudentDetail studentDetail;
+
+  // テスト用のモックBeanを定義
+  @TestConfiguration
+  static class MockConfig {
+    @Bean
+    public StudentService studentService() {
+      return Mockito.mock(StudentService.class); // Mockitoでモック化
+    }
+  }
+
+  @BeforeEach
+  void before() {
+
+
+    // テストデータ作成
+    baseStudent = new Student(
+        999, "テスト花子", "てすとはなこ", "てすこ", "test@email", "テスト区", (short) 19, "Other",
+        "");
+    baseCourses = List.of(
+        new StudentsCourse(998L, 999, "Javaコース", LocalDateTime.now(), LocalDateTime.now().plusYears(1)),
+        new StudentsCourse(999L, 999, "AWSコース", LocalDateTime.now(), LocalDateTime.now().plusYears(1)));
+    studentDetail = new StudentDetail(baseStudent, baseCourses);
+
+  }
+
+  private final Validator validator = buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  void 受講生一覧表示が実行でき_空のリストが返ってくること() throws Exception {
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/studentList"))
+        .andExpect(status().isOk())
+        .andExpect(content().json("[]"));
+
+    verify(service, times(1)).getStudentList();
+  }
+
+  @Test
+  void 受講生登録が実行でき_登録された受講生情報が返ってくること() throws Exception {
+
+    Mockito.when(service.registerStudent(Mockito.any())).thenReturn(studentDetail);
+
+    var objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    String request = objectMapper.writeValueAsString(studentDetail);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/registerStudent")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(request))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.student.nickname").value("てすこ"));
+
+    verify(service, times(1)).registerStudent(Mockito.any());
+  }
+
+  @Test
+  void 受講生検索が実行でき_受講生情報が返ってくること() throws Exception {
+    int studentId = 999;
+
+    Mockito.when(service.searchStudent(studentId)).thenReturn(studentDetail);
+
+    // リクエストの送信
+    mockMvc.perform(MockMvcRequestBuilders.get("/student/{studentId}", studentId)
+          .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.student.nickname").value("てすこ"));
+
+    verify(service, times(1)).searchStudent(studentId);
+  }
+
+  @Test
+  void 受講生更新が実行でき_実行結果が返ってくること() throws Exception {
+
+    // studentDetailをJSONに変換（日時加工）
+    var objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())  // 日付時刻をJSONに変換
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);  // タイムスタンプ形式を防ぐ
+    String request = objectMapper.writeValueAsString(studentDetail);
+
+    // PUT /updateStudent にJSONを送信
+    mockMvc.perform(MockMvcRequestBuilders.put("/updateStudent")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(request))
+        // レスポンスの検証
+        .andExpect(status().isOk())
+        .andExpect(content().string("テスト花子さんの更新処理が成功しました。"));
+
+    verify(service, times(1)).updateStudent(Mockito.any());
+  }
+
+  @Test
+  void 入力チェック_正常時はエラーなし_異常時はバリデーションエラーが発生すること() {
+
+    // 正常データ：エラーなし
+    Set<ConstraintViolation<Student>> violations = validator.validate(baseStudent);
+    assertThat(violations.size()).isEqualTo(0);  // エラーなし
+
+    // 異常値データ：エラー発生
+    var testStudent = new Student(
+        -1, "", "", "", "non.email", "", (short) -1, "", ""
+    );
+    Set<ConstraintViolation<Student>> testViolations = validator.validate(testStudent);
+    assertThat(testViolations.size()).isEqualTo(13);  // エラー数検証
+    for (ConstraintViolation<Student> v : testViolations) {  // エラー項目出力
+      System.out.println(v.getPropertyPath() + " :: " + v.getMessage());
+    }
+  }
+
+}


### PR DESCRIPTION
## 変更内容

* StudentControllerTestクラス作成
   * 各クラスのHTTPリクエスト対するレスポンスの検証テストを導入
   * バリデーションエラーのテスト導入
* ServiceクラスのsearchStudentメソッドにnullチェック追加

## 影響範囲

* searchStudentメソッドでnullチェックにより例外がスルーされるようになりました。

## 動作確認

### テスト実行結果
<img width="1518" alt="image" src="https://github.com/user-attachments/assets/c13c230d-1e8c-40d2-acb0-512d17cf4c31" />

### 受講生検索nullチェック
<img width="810" alt="image" src="https://github.com/user-attachments/assets/14da9e8d-5fcc-4cab-8904-a29aaa936f35" />


## その他

- 講義で使用されていた`@MockBean`は私の環境では使用できなかったため、`@Import`と`@TestConfigration`のネストで代用いたしました。