### PR TITLE
Feature/course status master

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,9 @@ erDiagram
     statuses {
         int status_id PK "ステータスID"
         varchar(20) status_name "ステータス名"
-        int display_order "表示順制御"
+        int display_order "表示順"
         boolean is_active "現在進行中か"
         boolean is_final "最終ステータスか"
-        boolean allow_new_registration "新規受講が可能か"
         timestamp created_at
         timestamp updated_at
     }

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ erDiagram
 ## その他
 
 - Postman
-- Git/GitHub
+- Git / GitHub
 - Docker
 
 # 機能一覧

--- a/docs/uml/er_diagram.md
+++ b/docs/uml/er_diagram.md
@@ -19,7 +19,7 @@ erDiagram
         date birth_date "誕生日"
         enum gender "[Male, Female, Other]"
         varchar(200) remark "備考"
-        boolean is_deleted "キャンセルフラグ"
+        boolean is_deleted "論理削除"
     }
 
     students_courses {
@@ -50,9 +50,8 @@ erDiagram
         int status_id PK "ステータスID"
         varchar(20) status_name "ステータス名"
         int display_order "表示順制御"
-        boolean is_active "現在進行中か"
-        boolean is_final "最終ステータスか"
-        boolean allow_new_registration "新規受講が可能か"
+        boolean is_active "進行中"
+        boolean is_final "最終状態"
         timestamp created_at
         timestamp updated_at
     }

--- a/docs/uml/er_diagram.md
+++ b/docs/uml/er_diagram.md
@@ -48,9 +48,11 @@ erDiagram
 
     statuses {
         int status_id PK "ステータスID"
-        varchar(20) category "ステータスカテゴリ"
+        varchar(20) status_name "ステータス名"
         int display_order "表示順制御"
-        boolean is_active "利用可否"
+        boolean is_active "現在進行中か"
+        boolean is_final "最終ステータスか"
+        boolean allow_new_registration "新規受講が可能か"
         timestamp created_at
         timestamp updated_at
     }

--- a/src/main/java/raisetech/student/management/controller/student/StudentSearchForm.java
+++ b/src/main/java/raisetech/student/management/controller/student/StudentSearchForm.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import raisetech.student.management.data.CourseStatus.Status;
 import raisetech.student.management.dto.StudentSearchDTO;
 
 @Schema(description = "検索フォーム")
@@ -43,8 +42,8 @@ public record StudentSearchForm(
     @Schema(description = "検索する受講終了日", example = "2000-01-01")
     LocalDate endDate,
 
-    @Schema(description = "検索する受講ステータス（リスト）", example = "[仮申し込み, 受講中]")
-    List<String> status
+    @Schema(description = "検索する受講ステータス（リスト）", example = "[5, 99]（ = 受講終了とキャンセル）")
+    List<Integer> statusIds
 
 ) {
 
@@ -63,16 +62,13 @@ public record StudentSearchForm(
         (minAge() != null) ? today.minusYears(minAge() + 1).minusDays(1)
             : null;
 
-    // statusについて、List<String>からList<Status>に変換
-    var statusDTOList = Optional.ofNullable(status())
-        .map(statusList -> statusList.stream().map(Status::valueOf).toList())
-        .orElse(List.of());  // statusがnullの時は空リストList.of()を返す
+    // statusIds が nullの場合、空リスト List.of() を返す
+    var statusIdList = Optional.ofNullable(statusIds).orElse(List.of());
 
     // リクエストデータをStudentSearchFormからStudentSearchDTOに詰め替え
     return new StudentSearchDTO(
         name(), startBirthDate, endBirthDate, area(), email(), gender(), remark(), courseId(),
-        category(),
-        startDate(), endDate(), statusDTOList);
+        category(), startDate(), endDate(), statusIdList);
 
   }
 

--- a/src/main/java/raisetech/student/management/data/CourseStatus.java
+++ b/src/main/java/raisetech/student/management/data/CourseStatus.java
@@ -21,11 +21,7 @@ public class CourseStatus {
   @Schema(description = "受講ID", example = "12")
   private Long attendingId;
 
-  @Schema(description = "受講・申し込み状況", example = "仮申し込み/本申し込み/受講中/受講終了")
-  private Status status;
-
-  public enum Status {
-    仮申し込み, 本申し込み, 受講中, 受講終了
-  }
+  @Schema(description = "ステータスID", example = "99（：キャンセル）※デフォルトは1（：仮申し込み）")
+  private Integer statusId;
 
 }

--- a/src/main/java/raisetech/student/management/data/Status.java
+++ b/src/main/java/raisetech/student/management/data/Status.java
@@ -1,0 +1,41 @@
+package raisetech.student.management.data;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.sql.Timestamp;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Schema(description = "ステータスマスタ")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Status {
+
+  @Schema(description = "ステータスID", example = "1")
+  private Integer statusId;
+
+  @Schema(description = "ステータス名", example = "受講中")
+  @NotNull
+  private String statusName;
+
+  @Schema(description = "表示順", example = "99")
+  @NotNull
+  private int displayOrder;
+
+  @Schema(description = "進行中")
+  private boolean isActive;
+
+  @Schema(description = "最終ステータス")
+  private boolean isFinal;
+
+  @Schema(description = "登録日時")
+  private Timestamp createdAt;
+
+  @Schema(description = "更新日時")
+  private Timestamp updatedAt;
+
+}

--- a/src/main/java/raisetech/student/management/dto/StudentSearchDTO.java
+++ b/src/main/java/raisetech/student/management/dto/StudentSearchDTO.java
@@ -41,7 +41,7 @@ public record StudentSearchDTO(
     LocalDate endDate,
 
     @Schema(description = "検索する受講ステータスID（リスト）", example = "[5, 7]（ = 受講中とキャンセル）")
-    List<Integer> statusId
+    List<Integer> statusIds
 
 ) {
 

--- a/src/main/java/raisetech/student/management/dto/StudentSearchDTO.java
+++ b/src/main/java/raisetech/student/management/dto/StudentSearchDTO.java
@@ -3,7 +3,6 @@ package raisetech.student.management.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
-import raisetech.student.management.data.CourseStatus.Status;
 
 @Schema(description = "検索条件オブジェクト")
 public record StudentSearchDTO(
@@ -41,8 +40,8 @@ public record StudentSearchDTO(
     @Schema(description = "検索する受講終了日", example = "2000-01-01")
     LocalDate endDate,
 
-    @Schema(description = "検索する受講ステータス（リスト）", example = "[Status.受講終了, Status.受講中]")
-    List<Status> status
+    @Schema(description = "検索する受講ステータスID（リスト）", example = "[5, 7]（ = 受講中とキャンセル）")
+    List<Integer> statusId
 
 ) {
 

--- a/src/main/java/raisetech/student/management/service/student/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/student/StudentService.java
@@ -142,11 +142,19 @@ public class StudentService {
       }
 
       // ステータス情報の登録
-      Optional.ofNullable(courseDetail.getStatus()).ifPresent(
-          status ->
-              status.setAttendingId(courseDetail.getCourse().getAttendingId())
-      );
-      registeredStatus += studentRepository.registerCourseStatus(courseDetail.getStatus());
+      CourseStatus courseStatus = courseDetail.getStatus();
+      if (courseStatus == null) {
+        courseStatus = new CourseStatus();
+        courseDetail.setStatus(courseStatus);
+      }
+
+      // attendingId は コース情報から取得
+      courseStatus.setAttendingId(courseDetail.getCourse().getAttendingId());
+      // status が null ならstudentID に 1（仮申し込み）をデフォルト設定
+      courseStatus.setStatusId(Optional.ofNullable(courseStatus.getStatusId()).orElse(1));
+
+      registeredStatus += studentRepository.registerCourseStatus(courseStatus);
+
     }
 
     // ステータス情報の登録が行われなかった場合に例外をthrow -> 処理中断

--- a/src/main/resources/raisetech/student/management/repository/student/StudentRepository.xml
+++ b/src/main/resources/raisetech/student/management/repository/student/StudentRepository.xml
@@ -140,9 +140,9 @@
   <select id="findStatus" resultType="raisetech.student.management.data.CourseStatus">
     SELECT DISTINCT * FROM course_status
     <where>
-      <if test='statusId != null and !statusId.isEmpty()'>
-        status IN (
-        <foreach item="item" index="index" collection="statusId" separator=",">
+      <if test='statusIds != null and !statusIds.isEmpty()'>
+        AND status_id IN (
+        <foreach item="item" index="index" collection="statusIds" separator=",">
           #{item}
         </foreach>
         )

--- a/src/main/resources/raisetech/student/management/repository/student/StudentRepository.xml
+++ b/src/main/resources/raisetech/student/management/repository/student/StudentRepository.xml
@@ -35,10 +35,12 @@
 
   <!-- 受講生情報の登録 -->
   <insert id="registerStudent" useGeneratedKeys="true" keyProperty="studentId">
-    INSERT INTO students(full_name, name_pronunciation, nickname, email, area, birth_date, gender,
-    remark)
-    VALUES (#{fullName}, #{namePronunciation}, #{nickname}, #{email}, #{area}, #{birthDate},
-    #{gender}, #{remark})
+    INSERT INTO students(
+    full_name, name_pronunciation, nickname, email, area, birth_date, gender, remark
+    ) VALUES (
+    #{fullName}, #{namePronunciation}, #{nickname}, #{email}, #{area}, #{birthDate},
+    #{gender}, #{remark}
+    )
   </insert>
 
   <!-- コース情報の登録 -->
@@ -47,10 +49,15 @@
     VALUES (#{studentId}, #{courseId}, #{startDate}, #{endDate})
   </insert>
 
-  <!-- 受講ステータスの登録 -->
+  <!-- 受講ステータスの登録（ステータスIDは1（仮申し込み）がdefault） -->
   <insert id="registerCourseStatus" useGeneratedKeys="true" keyProperty="id">
-    INSERT INTO course_status(attending_id, status)
-    VALUES (#{attendingId}, #{status})
+    INSERT INTO course_status(attending_id, status_id)
+    VALUES (#{attendingId},
+    <choose>
+      <when test="statusId != null">#{statusId}</when>
+      <otherwise>1</otherwise>
+    </choose>
+    )
   </insert>
 
   <!-- 受講生情報の更新 -->
@@ -77,7 +84,7 @@
 
   <!-- 受講状況・申し込み状況の更新 -->
   <update id="updateCourseStatus">
-    UPDATE course_status SET status = #{status} WHERE id = #{id}
+    UPDATE course_status SET status_id = #{statusId} WHERE id = #{id}
   </update>
 
   <!-- 受講生の詳細検索 -->
@@ -133,9 +140,9 @@
   <select id="findStatus" resultType="raisetech.student.management.data.CourseStatus">
     SELECT DISTINCT * FROM course_status
     <where>
-      <if test='status != null and !status.isEmpty()'>
+      <if test='statusId != null and !statusId.isEmpty()'>
         status IN (
-        <foreach item="item" index="index" collection="status" separator=",">
+        <foreach item="item" index="index" collection="statusId" separator=",">
           #{item}
         </foreach>
         )

--- a/src/test/java/raisetech/student/management/controller/student/StudentControllerTest.java
+++ b/src/test/java/raisetech/student/management/controller/student/StudentControllerTest.java
@@ -29,7 +29,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import raisetech.student.management.data.CourseStatus;
-import raisetech.student.management.data.CourseStatus.Status;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentsCourse;
 import raisetech.student.management.domain.CourseDetail;
@@ -80,11 +79,11 @@ class StudentControllerTest {
 
     courseDetail1 = new CourseDetail(
         new StudentsCourse(998L, 999, 1, fixedDateTime, fixedDateTime.plusYears(1)),
-        new CourseStatus(1, 998L, Status.受講終了)
+        new CourseStatus(1, 998L, 5)
     );
     courseDetail2 = new CourseDetail(
         new StudentsCourse(999L, 999, 2, fixedDateTime, fixedDateTime.plusYears(1)),
-        new CourseStatus(2, 999L, Status.受講中)
+        new CourseStatus(2, 999L, 4)
     );
 
     studentDetail = new StudentDetail(student, List.of(courseDetail1, courseDetail2));
@@ -163,7 +162,7 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.courseDetailList[0].course.endDate").value("2022-05-07T16:00:00"))
         .andExpect(jsonPath("$.courseDetailList[0].status.id").value("1"))
         .andExpect(jsonPath("$.courseDetailList[0].status.attendingId").value("998"))
-        .andExpect(jsonPath("$.courseDetailList[0].status.status").value("受講終了"))
+        .andExpect(jsonPath("$.courseDetailList[0].status.statusId").value("5"))
         .andExpect(jsonPath("$.courseDetailList[1].course.attendingId").value("999"))
         .andExpect(jsonPath("$.courseDetailList[1].course.studentId").value("999"))
         .andExpect(jsonPath("$.courseDetailList[1].course.courseId").value("2"))
@@ -171,7 +170,7 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.courseDetailList[1].course.endDate").value("2022-05-07T16:00:00"))
         .andExpect(jsonPath("$.courseDetailList[1].status.id").value("2"))
         .andExpect(jsonPath("$.courseDetailList[1].status.attendingId").value("999"))
-        .andExpect(jsonPath("$.courseDetailList[1].status.status").value("受講中"));
+        .andExpect(jsonPath("$.courseDetailList[1].status.statusId").value("4"));
 
     verify(service, times(1)).registerStudent(any());
   }
@@ -205,7 +204,7 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.courseDetailList[0].course.endDate").value("2022-05-07T16:00:00"))
         .andExpect(jsonPath("$.courseDetailList[0].status.id").value("1"))
         .andExpect(jsonPath("$.courseDetailList[0].status.attendingId").value("998"))
-        .andExpect(jsonPath("$.courseDetailList[0].status.status").value("受講終了"))
+        .andExpect(jsonPath("$.courseDetailList[0].status.statusId").value("5"))
         .andExpect(jsonPath("$.courseDetailList[1].course.attendingId").value("999"))
         .andExpect(jsonPath("$.courseDetailList[1].course.studentId").value("999"))
         .andExpect(jsonPath("$.courseDetailList[1].course.courseId").value("2"))
@@ -213,7 +212,7 @@ class StudentControllerTest {
         .andExpect(jsonPath("$.courseDetailList[1].course.endDate").value("2022-05-07T16:00:00"))
         .andExpect(jsonPath("$.courseDetailList[1].status.id").value("2"))
         .andExpect(jsonPath("$.courseDetailList[1].status.attendingId").value("999"))
-        .andExpect(jsonPath("$.courseDetailList[1].status.status").value("受講中"));
+        .andExpect(jsonPath("$.courseDetailList[1].status.statusId").value("4"));
 
     verify(service, times(1)).searchStudent(studentId);
   }

--- a/src/test/java/raisetech/student/management/controller/student/StudentSearchFormTest.java
+++ b/src/test/java/raisetech/student/management/controller/student/StudentSearchFormTest.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
-import raisetech.student.management.data.CourseStatus.Status;
 import raisetech.student.management.dto.StudentSearchDTO;
 
 class StudentSearchFormTest {
@@ -12,10 +11,8 @@ class StudentSearchFormTest {
   @Test
   void DTOへの変換メソッド_すべての値が正しく変換されること() {
     // 入力データの準備
-    var form = new StudentSearchForm("テスト", 25, 30,
-        "テスト", "test@email.com", "Other",
-        "", 1, "開発系コース", LocalDate.of(2025, 1, 1), LocalDate.of(2025, 7, 1),
-        List.of("受講中"));
+    var form = new StudentSearchForm("テスト", 25, 30, "テスト", "test@email.com", "Other", "", 1,
+        "開発系コース", LocalDate.of(2025, 1, 1), LocalDate.of(2025, 7, 1), List.of(4));
 
     StudentSearchDTO actual = form.toDTO();
 
@@ -26,7 +23,7 @@ class StudentSearchFormTest {
 
     var expected = new StudentSearchDTO("テスト", expectedStartBirthDate, expectedEndBirthDate,
         "テスト", "test@email.com", "Other", "", 1, "開発系コース", LocalDate.of(2025, 1, 1),
-        LocalDate.of(2025, 7, 1), List.of(Status.受講中));
+        LocalDate.of(2025, 7, 1), List.of(4));
 
     // 検証
     assertThat(actual).isEqualTo(expected);
@@ -35,10 +32,8 @@ class StudentSearchFormTest {
   @Test
   void DTOへの変換メソッド_年齢指定なしの場合_生年月日指定がNullになること() {
     // 入力データの準備
-    var form = new StudentSearchForm("テスト", null, null,
-        "テスト", "test@email.com", "Other",
-        "", 1, "開発系コース", LocalDate.of(2025, 1, 1), LocalDate.of(2025, 7, 1),
-        List.of("受講中"));
+    var form = new StudentSearchForm("テスト", null, null, "テスト", "test@email.com", "Other", "",
+        1, "開発系コース", LocalDate.of(2025, 1, 1), LocalDate.of(2025, 7, 1), List.of(4));
 
     var dto = form.toDTO();
 
@@ -54,7 +49,7 @@ class StudentSearchFormTest {
 
     StudentSearchDTO dto = form.toDTO();
 
-    assertThat(dto.status()).isEmpty();
+    assertThat(dto.statusIds()).isEmpty();
   }
 
 }

--- a/src/test/java/raisetech/student/management/converter/student/StudentConverterTest.java
+++ b/src/test/java/raisetech/student/management/converter/student/StudentConverterTest.java
@@ -6,7 +6,6 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import raisetech.student.management.data.CourseStatus;
-import raisetech.student.management.data.CourseStatus.Status;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentsCourse;
 import raisetech.student.management.domain.CourseDetail;
@@ -40,9 +39,9 @@ class StudentConverterTest {
         fixedDateTime.plusYears(1));
     List<StudentsCourse> studentsCourseList = List.of(course1, course2, course3);
 
-    var status1 = new CourseStatus(1, 111L, Status.受講中);
-    var status2 = new CourseStatus(2, 222L, Status.本申し込み);
-    var status3 = new CourseStatus(3, 333L, Status.仮申し込み);
+    var status1 = new CourseStatus(1, 111L, 4);
+    var status2 = new CourseStatus(2, 222L, 3);
+    var status3 = new CourseStatus(3, 333L, 1);
     List<CourseStatus> courseStatusList = List.of(status1, status2, status3);
 
     List<CourseDetail> courseDetailList = List.of(
@@ -87,9 +86,9 @@ class StudentConverterTest {
         fixedDateTime.plusYears(1));
     List<StudentsCourse> studentsCourseList = List.of(course1, course2, course3);
 
-    var status1 = new CourseStatus(1, attendingId1, Status.受講中);
-    var status2 = new CourseStatus(2, attendingId2, Status.本申し込み);
-    var status3 = new CourseStatus(3, attendingId3, Status.仮申し込み);
+    var status1 = new CourseStatus(1, attendingId1, 4);
+    var status2 = new CourseStatus(2, attendingId2, 3);
+    var status3 = new CourseStatus(3, attendingId3, 1);
     List<CourseStatus> courseStatusList = List.of(status1, status2, status3);
 
     // expectedを用意

--- a/src/test/java/raisetech/student/management/repository/student/StudentRepositoryTest.java
+++ b/src/test/java/raisetech/student/management/repository/student/StudentRepositoryTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import raisetech.student.management.data.CourseStatus;
-import raisetech.student.management.data.CourseStatus.Status;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentsCourse;
 import raisetech.student.management.dto.StudentSearchDTO;
@@ -49,13 +48,13 @@ class StudentRepositoryTest {
   private final List<StudentsCourse> studentsCourseList = List.of(course1, course2, course3,
       course4, course5, course6, course7);
 
-  CourseStatus status1 = new CourseStatus(1, 1L, Status.受講終了);
-  CourseStatus status2 = new CourseStatus(2, 2L, Status.受講終了);
-  CourseStatus status3 = new CourseStatus(3, 3L, Status.受講中);
-  CourseStatus status4 = new CourseStatus(4, 4L, Status.受講中);
-  CourseStatus status5 = new CourseStatus(5, 5L, Status.本申し込み);
-  CourseStatus status6 = new CourseStatus(6, 6L, Status.本申し込み);
-  CourseStatus status7 = new CourseStatus(7, 7L, Status.仮申し込み);
+  CourseStatus status1 = new CourseStatus(1, 1L, 5);
+  CourseStatus status2 = new CourseStatus(2, 2L, 5);
+  CourseStatus status3 = new CourseStatus(3, 3L, 4);
+  CourseStatus status4 = new CourseStatus(4, 4L, 4);
+  CourseStatus status5 = new CourseStatus(5, 5L, 3);
+  CourseStatus status6 = new CourseStatus(6, 6L, 3);
+  CourseStatus status7 = new CourseStatus(7, 7L, 1);
   private final List<CourseStatus> courseStatusList = List.of(status1, status2, status3, status4,
       status5, status6, status7);
 
@@ -121,7 +120,7 @@ class StudentRepositoryTest {
 
   @Test
   void 受講ステータスの登録が行えること() {
-    var status = new CourseStatus(null, 1L, Status.受講終了);
+    var status = new CourseStatus(null, 1L, 5);
     int actual = sut.registerCourseStatus(status);
     assertThat(actual).isEqualTo(1);
   }
@@ -164,13 +163,13 @@ class StudentRepositoryTest {
   @Test
   void 受講ステータスの更新が行えること() {
     int id = 1;
-    var status = new CourseStatus(id, 1L, Status.仮申し込み);
+    var status = new CourseStatus(id, 1L, 1);
 
     int updated = sut.updateCourseStatus(status);
     var actual = sut.searchCourseStatus(1L);
 
     assertEquals(1, updated);
-    assertEquals(status.getStatus(), actual.getStatus());
+    assertEquals(status.getStatusId(), actual.getStatusId());
   }
 
   @Test
@@ -204,12 +203,12 @@ class StudentRepositoryTest {
     // 検索条件
     var condition = new StudentSearchDTO(
         null, null, null, null, null, null, null,
-        null, null, null, null, List.of(Status.受講中));
+        null, null, null, null, List.of(4));
 
     var statuses = sut.findStatus(condition);
 
     assertThat(statuses).isNotEmpty();
-    assertThat(statuses.getFirst().getStatus()).isEqualTo(Status.受講中);
+    assertThat(statuses.getFirst().getStatusId()).isEqualTo(4);
   }
 
 }

--- a/src/test/java/raisetech/student/management/service/student/StudentServiceTest.java
+++ b/src/test/java/raisetech/student/management/service/student/StudentServiceTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 import raisetech.student.management.converter.student.StudentConverter;
 import raisetech.student.management.data.CourseStatus;
-import raisetech.student.management.data.CourseStatus.Status;
 import raisetech.student.management.data.Student;
 import raisetech.student.management.data.StudentsCourse;
 import raisetech.student.management.domain.CourseDetail;
@@ -80,8 +79,8 @@ class StudentServiceTest {
         LocalDateTime.now().plusYears(1));
     courseList = List.of(course1, course2);
 
-    status1 = new CourseStatus(1, attendingId1, Status.受講終了);
-    status2 = new CourseStatus(1, attendingId2, Status.受講中);
+    status1 = new CourseStatus(1, attendingId1, 5);
+    status2 = new CourseStatus(1, attendingId2, 4);
 
     courseDetail1 = new CourseDetail(course1, status1);
     courseDetail2 = new CourseDetail(course2, status2);
@@ -262,8 +261,8 @@ class StudentServiceTest {
         LocalDateTime.now().plusYears(1));
     var updateCourses = List.of(updateCourse1, updateCourse2);
 
-    var updateStatus1 = new CourseStatus(1, attendingId1, Status.受講終了);
-    var updateStatus2 = new CourseStatus(2, attendingId2, Status.受講終了);
+    var updateStatus1 = new CourseStatus(1, attendingId1, 5);
+    var updateStatus2 = new CourseStatus(2, attendingId2, 5);
     var updateStatuses = List.of(updateStatus1, updateStatus2);
 
     var updateCourseDetails = List.of(

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -17,14 +17,14 @@ INSERT INTO students_courses (student_id, course_id, start_date, end_date) VALUE
 (2, 7, '2025-07-10', '2026-01-10'); -- 鈴木 花子が複数のコースを受講;
 
 -- course_status テーブルにデータを挿入
-INSERT INTO course_status (attending_id, status) VALUES
-(1, '受講終了'),
-(2, '受講終了'),
-(3, '受講中'),
-(4, '受講中'),
-(5, '本申し込み'),
-(6, '本申し込み'),
-(7, '仮申し込み');
+INSERT INTO course_status (attending_id, status_id) VALUES
+(1, 5),
+(2, 5),
+(3, 4),
+(4, 4),
+(5, 3),
+(6, 3),
+(7, 1);
 
 -- courses テーブルにデータを挿入　
 INSERT INTO courses (course_name, category, duration, is_closed) VALUES
@@ -35,3 +35,13 @@ INSERT INTO courses (course_name, category, duration, is_closed) VALUES
 ('webマーケティングコース', '制作系コース', 6, 0),
 ('映像制作コース', '制作系コース', 6, 0),
 ('フロントエンドコース', '開発系コース', 6, 0);
+
+-- statuses テーブルにデータを挿入
+INSERT INTO statuses (status_name, display_order, is_active, is_final) VALUES
+('仮申し込み', 1, 0, 0),
+('入金待ち', 2, 0, 0),
+('本申し込み', 3, 0, 0),
+('受講中', 4, 1, 0),
+('受講終了', 5, 0, 1),
+('受講中断', 6, 0, 0),
+('キャンセル', 99, 0, 1);

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -16,6 +16,16 @@ INSERT INTO students_courses (student_id, course_id, start_date, end_date) VALUE
 (1, 6, '2025-06-01', '2025-12-01'), -- 山田 太郎が複数のコースを受講
 (2, 7, '2025-07-10', '2026-01-10'); -- 鈴木 花子が複数のコースを受講;
 
+-- statuses テーブルにデータを挿入
+INSERT INTO statuses (status_name, display_order, is_active, is_final) VALUES
+('仮申し込み', 1, 0, 0),
+('入金待ち', 2, 0, 0),
+('本申し込み', 3, 0, 0),
+('受講中', 4, 1, 0),
+('受講終了', 5, 0, 1),
+('受講中断', 6, 0, 0),
+('キャンセル', 99, 0, 1);
+
 -- course_status テーブルにデータを挿入
 INSERT INTO course_status (attending_id, status_id) VALUES
 (1, 5),
@@ -35,13 +45,3 @@ INSERT INTO courses (course_name, category, duration, is_closed) VALUES
 ('webマーケティングコース', '制作系コース', 6, 0),
 ('映像制作コース', '制作系コース', 6, 0),
 ('フロントエンドコース', '開発系コース', 6, 0);
-
--- statuses テーブルにデータを挿入
-INSERT INTO statuses (status_name, display_order, is_active, is_final) VALUES
-('仮申し込み', 1, 0, 0),
-('入金待ち', 2, 0, 0),
-('本申し込み', 3, 0, 0),
-('受講中', 4, 1, 0),
-('受講終了', 5, 0, 1),
-('受講中断', 6, 0, 0),
-('キャンセル', 99, 0, 1);

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -1,3 +1,13 @@
+CREATE TABLE statuses (
+    status_id INT AUTO_INCREMENT PRIMARY KEY,
+    status_name VARCHAR(20) NOT NULL,
+    display_order INT NOT NULL,
+    is_active TINYINT NOT NULL DEFAULT 0,
+    is_final TINYINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
 CREATE TABLE students (
     student_id INT AUTO_INCREMENT PRIMARY KEY,
     full_name VARCHAR(50) NOT NULL,
@@ -10,6 +20,16 @@ CREATE TABLE students (
     remark VARCHAR(200) NULL,
     is_deleted TINYINT NOT NULL DEFAULT 0,
     CHECK (gender IN ('Male', 'Female', 'Other'))
+);
+
+CREATE TABLE courses (
+    course_id INT AUTO_INCREMENT PRIMARY KEY,
+    course_name VARCHAR(50) NOT NULL,
+    category VARCHAR(20) NOT NULL,
+    duration INT NOT NULL DEFAULT 6,
+    is_closed TINYINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
 CREATE TABLE students_courses (
@@ -29,25 +49,5 @@ CREATE TABLE course_status (
     CONSTRAINT fk_course_status_attending FOREIGN KEY (attending_id)
         REFERENCES students_courses(attending_id) ON DELETE CASCADE,
     CONSTRAINT fk_course_status_status FOREIGN KEY (status_id)
-        REFERENCES statuses(status_id);
-);
-
-CREATE TABLE courses (
-    course_id INT AUTO_INCREMENT PRIMARY KEY,
-    course_name VARCHAR(50) NOT NULL,
-    category VARCHAR(20) NOT NULL,
-    duration INT NOT NULL DEFAULT 6,
-    is_closed TINYINT NOT NULL DEFAULT 0,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-);
-
-CREATE TABLE statuses (
-    status_id INT AUTO_INCREMENT PRIMARY KEY,
-    status_name VARCHAR(20) NOT NULL,
-    display_order INT NOT NULL,
-    is_active TINYINT NOT NULL DEFAULT 0,
-    is_final TINYINT NOT NULL DEFAULT 0,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        REFERENCES statuses(status_id)
 );

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -25,9 +25,11 @@ CREATE TABLE students_courses (
 CREATE TABLE course_status (
     id INT AUTO_INCREMENT PRIMARY KEY,
     attending_id INT NOT NULL,
-    status ENUM('仮申し込み', '本申し込み', '受講中', '受講終了') NOT NULL,
+    status_id INT NOT NULL,
     CONSTRAINT fk_course_status_attending FOREIGN KEY (attending_id)
-        REFERENCES students_courses(attending_id) ON DELETE CASCADE
+        REFERENCES students_courses(attending_id) ON DELETE CASCADE,
+    CONSTRAINT fk_course_status_status FOREIGN KEY (status_id)
+        REFERENCES statuses(status_id);
 );
 
 CREATE TABLE courses (
@@ -38,4 +40,14 @@ CREATE TABLE courses (
     is_closed TINYINT NOT NULL DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE statuses (
+    status_id INT AUTO_INCREMENT PRIMARY KEY,
+    status_name VARCHAR(20) NOT NULL,
+    display_order INT NOT NULL,
+    is_active TINYINT NOT NULL DEFAULT 0,
+    is_final TINYINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
## 変更の概要

* StatusをEnum制御からマスタ管理に変更
   * `Status`クラスを導入
   * 関連するメソッド等書き換え、エンドポイント名変更（`status` -> `statusIds`）

| カラム名        | 型             | 説明                         | 備考 |
|----------------|----------------|--------------------|-----------------|
| `status_id`     | `int` (PK)      | ステータスID                  | デフォルト：仮申し込み(1) |
| `status_name`   | `varchar(20)`   | ステータス名                  |  |
| `display_order` | `int`           | 表示順                        |  |
| `is_active`     | `boolean`       | 進行中             |  |
| `is_final`      | `boolean`       | 最終ステータス         |  |
| `created_at`    | `timestamp`     | 作成日時                      |  |
| `updated_at`    | `timestamp`     | 更新日時                      |  |


* 関連PR #19 

## なぜこの変更をするのか

* マスタ化により
   * 柔軟なステータス管理（変更・追加もDB上で対応可能）
   * 表示順、進行中か、最終ステータスか、などの属性による分岐やフィルタが可能になる

## やったこと

* [x] Statusのマスタ化
* [ ] マスタ化を利用した機能の導入

## 変更内容

* UIの変更ならスクリーンショット
* APIの変更ならリクエストとレスポンス

## 影響範囲

* ユーザーに影響すること
* メンバーに影響すること
* システムに影響すること

## 動作確認

* 使い方
* 再現手順

## 課題

* 悩んでいること
* とくにレビューしてほしいところ

## 備考

* その他に伝えたいこと